### PR TITLE
A script to write the pages' object hierarchy

### DIFF
--- a/dict_util.py
+++ b/dict_util.py
@@ -1,3 +1,6 @@
+_STREAM_WRITING_MODES = ("r+", "w", "w+", "a", "a+")
+
+
 def dict_to_lines(a_dict):
 	key_val_lines = list()
 
@@ -14,3 +17,17 @@ def print_dict(a_dict, title=None):
 	key_val_lines = dict_to_lines(a_dict)
 	for line in key_val_lines:
 		print(line)
+
+
+def write_dict_in_stream(a_dict, w_stream, before_line=None, after_line=None):
+	assert(w_stream.mode in _STREAM_WRITING_MODES)
+
+	key_val_lines = dict_to_lines(a_dict)
+	for line in key_val_lines:
+		if before_line is not None:
+			line = before_line + line
+
+		if after_line is not None:
+			line += after_line
+
+		w_stream.write(line)

--- a/write_page_dicts.py
+++ b/write_page_dicts.py
@@ -37,7 +37,7 @@ def _write_page_objs_rec(w_stream, obj_to_write, indent=0):
 			if isinstance(value, dict):
 				_write_page_objs_rec(w_stream, value, indent)
 			else:
-				line += _obj_and_type_to_str(value)
+				line += " " + _obj_and_type_to_str(value)
 
 			w_stream.write(line + "\n")
 

--- a/write_page_dicts.py
+++ b/write_page_dicts.py
@@ -1,7 +1,54 @@
-from dict_util import write_dict_in_stream
 from pathlib import Path
 from PyPDF2 import PdfFileReader
+from PyPDF2.generic import PdfObject
 from sys import argv
+
+
+def _make_tabs(n):
+	return "\t" * n
+
+
+def _obj_and_type_to_str(obj):
+	return str(obj) + " " + str(type(obj))
+
+
+def _write_page_objs_rec(w_stream, obj_to_write, indent=0):
+	tabs = _make_tabs(indent)
+	indent += 1
+
+	if isinstance(obj_to_write, PdfObject):
+		obj_to_write = obj_to_write.getObject()
+
+	if isinstance(obj_to_write, (list, tuple)):
+		length = len(obj_to_write)
+
+		for i in range(length):
+			item = obj_to_write[i]
+
+			if isinstance(item, (dict, list, set, tuple)):
+				_write_page_objs_rec(w_stream, item, indent)
+			else:
+				w_stream.write(tabs + "[" + str(i) + "]: " + _obj_and_type_to_str(item) + "\n")
+
+	elif isinstance(obj_to_write, dict):
+		for key, value in obj_to_write.items():
+			line = tabs + str(key) + ":"
+
+			if isinstance(value, dict):
+				_write_page_objs_rec(w_stream, value, indent)
+			else:
+				line += _obj_and_type_to_str(value)
+
+			w_stream.write(line + "\n")
+
+	elif isinstance(obj_to_write, set):
+		for item in obj_to_write:
+			if isinstance(item, (dict, list, set, tuple)):
+				_write_page_objs_rec(w_stream, item, indent)
+			else:
+				w_stream.write(tabs + _obj_and_type_to_str(item) + "\n")
+
+	w_stream.write(tabs + str(obj_to_write) + "\n")
 
 
 try:
@@ -22,6 +69,6 @@ with output_path.open("w") as output_stream:
 	output_stream.write("Content of " + str(input_path) + "\n")
 
 	for i in range(len(pages)):
+		page = pages[i]
 		output_stream.write("\nPage " + str(i) + "\n")
-		write_dict_in_stream(pages[i], output_stream, after_line="\n")
-		#output_stream.write("\n")
+		_write_page_objs_rec(output_stream, page)

--- a/write_page_dicts.py
+++ b/write_page_dicts.py
@@ -8,6 +8,7 @@ try:
 	input_path = Path(argv[1])
 except IndexError:
 	print("The path to a PDF file must be provided as an argument.")
+	exit()
 
 try:
 	output_path = Path(argv[2])
@@ -18,7 +19,9 @@ reader = PdfFileReader(input_path.open("rb"))
 pages = reader.pages
 
 with output_path.open("w") as output_stream:
+	output_stream.write("Content of " + str(input_path) + "\n")
+
 	for i in range(len(pages)):
-		output_stream.write("Page " + str(i) + "\n")
+		output_stream.write("\nPage " + str(i) + "\n")
 		write_dict_in_stream(pages[i], output_stream, after_line="\n")
-		output_stream.write("\n")
+		#output_stream.write("\n")

--- a/write_page_dicts.py
+++ b/write_page_dicts.py
@@ -1,0 +1,24 @@
+from dict_util import write_dict_in_stream
+from pathlib import Path
+from PyPDF2 import PdfFileReader
+from sys import argv
+
+
+try:
+	input_path = Path(argv[1])
+except IndexError:
+	print("The path to a PDF file must be provided as an argument.")
+
+try:
+	output_path = Path(argv[2])
+except IndexError:
+	output_path = input_path.parents[0]/(input_path.stem + ".txt")
+
+reader = PdfFileReader(input_path.open("rb"))
+pages = reader.pages
+
+with output_path.open("w") as output_stream:
+	for i in range(len(pages)):
+		output_stream.write("Page " + str(i) + "\n")
+		write_dict_in_stream(pages[i], output_stream, after_line="\n")
+		output_stream.write("\n")

--- a/write_page_objects.py
+++ b/write_page_objects.py
@@ -1,4 +1,4 @@
-# Exlores recursively the objects in a PDF file's pages and records their
+# Explores recursively the objects in a PDF file's pages and records their
 # hierachy in a .txt file.
 # argv[1]: path to the PDF file to explore
 # argv[2]: (optional) path to the .txt output file

--- a/write_page_objects.py
+++ b/write_page_objects.py
@@ -88,5 +88,5 @@ with output_path.open("w") as output_stream:
 
 	for i in range(len(pages)):
 		page = pages[i]
-		output_stream.write("\nPage " + str(i) + "\n")
+		output_stream.write("\n\nPAGE " + str(i) + "\n")
 		_write_page_objects_rec(output_stream, page)

--- a/write_page_objects.py
+++ b/write_page_objects.py
@@ -12,6 +12,18 @@ from sys import argv
 
 _DLST = (dict, list, set, tuple)
 
+_INPUT_EXTENSION = ".pdf"
+
+_INPUT_EXTENSION_LIST = [_INPUT_EXTENSION]
+
+_OUTPUT_EXTENSION = ".txt"
+
+_OUTPUT_EXTENSION_LIST = [_OUTPUT_EXTENSION]
+
+
+def _make_default_output_file_name(input_path):
+	return input_path.stem + "_object_hierarchy" + _OUTPUT_EXTENSION
+
 
 def _make_tabs(n):
 	return "\t" * n
@@ -23,6 +35,10 @@ def _obj_and_type_to_str(obj):
 
 def _obj_is_a_dlst(obj):
 	return isinstance(obj, _DLST)
+
+
+def _replace_extension(a_path, extension):
+	return a_path.parents[0]/(a_path.stem + extension)
 
 
 def _write_page_objects_rec(w_stream, obj_to_write, indent=0):
@@ -72,13 +88,26 @@ def _write_page_objects_rec(w_stream, obj_to_write, indent=0):
 try:
 	input_path = Path(argv[1])
 except IndexError:
-	print("The path to a PDF file must be provided as an argument.")
+	print("ERROR! The path to a " + _INPUT_EXTENSION
+		+ " file must be provided as the first argument.")
+	exit()
+
+if not input_path.exists():
+	print("ERROR! Path " + str(input_path) + " does not exist.")
+	exit()
+elif input_path.suffixes != _INPUT_EXTENSION_LIST:
+	print("ERROR! The first argument must be the path to a "
+		+ _INPUT_EXTENSION + " file.")
 	exit()
 
 try:
 	output_path = Path(argv[2])
+	if output_path.is_dir():
+		output_path = output_path/_make_default_output_file_name(input_path)
+	elif output_path.suffixes != _OUTPUT_EXTENSION_LIST:
+		output_path = _replace_extension(output_path, _OUTPUT_EXTENSION)
 except IndexError:
-	output_path = input_path.parents[0]/(input_path.stem + "_object_hierarchy.txt")
+	output_path = input_path.parents[0]/_make_default_output_file_name(input_path)
 
 reader = PdfFileReader(input_path.open("rb"))
 pages = reader.pages

--- a/write_page_objects.py
+++ b/write_page_objects.py
@@ -1,3 +1,9 @@
+# Exlores recursively the objects in a PDF file's pages and records their
+# hierachy in a .txt file.
+# argv[1]: path to the PDF file to explore
+# argv[2]: (optional) path to the .txt output file
+
+
 from pathlib import Path
 from PyPDF2 import PdfFileReader
 from PyPDF2.generic import PdfObject

--- a/write_page_objects.py
+++ b/write_page_objects.py
@@ -78,13 +78,13 @@ except IndexError:
 try:
 	output_path = Path(argv[2])
 except IndexError:
-	output_path = input_path.parents[0]/(input_path.stem + ".txt")
+	output_path = input_path.parents[0]/(input_path.stem + "_object_hierarchy.txt")
 
 reader = PdfFileReader(input_path.open("rb"))
 pages = reader.pages
 
 with output_path.open("w") as output_stream:
-	output_stream.write("Content of " + str(input_path) + "\n")
+	output_stream.write("Object hierachy of " + str(input_path) + "\n")
 
 	for i in range(len(pages)):
 		page = pages[i]

--- a/write_page_objects.py
+++ b/write_page_objects.py
@@ -12,7 +12,7 @@ def _obj_and_type_to_str(obj):
 	return str(obj) + " " + str(type(obj))
 
 
-def _write_page_objs_rec(w_stream, obj_to_write, indent=0):
+def _write_page_objects_rec(w_stream, obj_to_write, indent=0):
 	tabs = _make_tabs(indent)
 	indent += 1
 
@@ -26,7 +26,7 @@ def _write_page_objs_rec(w_stream, obj_to_write, indent=0):
 			item = obj_to_write[i]
 
 			if isinstance(item, (dict, list, set, tuple)):
-				_write_page_objs_rec(w_stream, item, indent)
+				_write_page_objects_rec(w_stream, item, indent)
 			else:
 				w_stream.write(tabs + "[" + str(i) + "]: " + _obj_and_type_to_str(item) + "\n")
 
@@ -35,7 +35,7 @@ def _write_page_objs_rec(w_stream, obj_to_write, indent=0):
 			line = tabs + str(key) + ":"
 
 			if isinstance(value, dict):
-				_write_page_objs_rec(w_stream, value, indent)
+				_write_page_objects_rec(w_stream, value, indent)
 			else:
 				line += " " + _obj_and_type_to_str(value)
 
@@ -44,7 +44,7 @@ def _write_page_objs_rec(w_stream, obj_to_write, indent=0):
 	elif isinstance(obj_to_write, set):
 		for item in obj_to_write:
 			if isinstance(item, (dict, list, set, tuple)):
-				_write_page_objs_rec(w_stream, item, indent)
+				_write_page_objects_rec(w_stream, item, indent)
 			else:
 				w_stream.write(tabs + _obj_and_type_to_str(item) + "\n")
 
@@ -71,4 +71,4 @@ with output_path.open("w") as output_stream:
 	for i in range(len(pages)):
 		page = pages[i]
 		output_stream.write("\nPage " + str(i) + "\n")
-		_write_page_objs_rec(output_stream, page)
+		_write_page_objects_rec(output_stream, page)

--- a/write_page_objects.py
+++ b/write_page_objects.py
@@ -35,7 +35,9 @@ def _write_page_objects_rec(w_stream, obj_to_write, indent=0):
 			if _obj_is_a_dlst(item):
 				_write_page_objects_rec(w_stream, item, indent)
 			else:
-				w_stream.write(tabs + "[" + str(i) + "]: " + _obj_and_type_to_str(item) + "\n")
+				line = tabs + "[" + str(i) + "]: "\
+					+ _obj_and_type_to_str(item)
+				w_stream.write(line + "\n")
 
 	elif isinstance(obj_to_write, dict):
 		for key, value in obj_to_write.items():
@@ -53,9 +55,12 @@ def _write_page_objects_rec(w_stream, obj_to_write, indent=0):
 			if _obj_is_a_dlst(item):
 				_write_page_objects_rec(w_stream, item, indent)
 			else:
-				w_stream.write(tabs + _obj_and_type_to_str(item) + "\n")
+				line = tabs + _obj_and_type_to_str(item)
+				w_stream.write(line + "\n")
 
-	w_stream.write(tabs + str(obj_to_write) + "\n")
+	else:
+		line = tabs + str(obj_to_write)
+		w_stream.write(line + "\n")
 
 
 try:

--- a/write_page_objects.py
+++ b/write_page_objects.py
@@ -4,12 +4,19 @@ from PyPDF2.generic import PdfObject
 from sys import argv
 
 
+_DLST = (dict, list, set, tuple)
+
+
 def _make_tabs(n):
 	return "\t" * n
 
 
 def _obj_and_type_to_str(obj):
 	return str(obj) + " " + str(type(obj))
+
+
+def _obj_is_a_dlst(obj):
+	return isinstance(obj, _DLST)
 
 
 def _write_page_objects_rec(w_stream, obj_to_write, indent=0):
@@ -25,7 +32,7 @@ def _write_page_objects_rec(w_stream, obj_to_write, indent=0):
 		for i in range(length):
 			item = obj_to_write[i]
 
-			if isinstance(item, (dict, list, set, tuple)):
+			if _obj_is_a_dlst(item):
 				_write_page_objects_rec(w_stream, item, indent)
 			else:
 				w_stream.write(tabs + "[" + str(i) + "]: " + _obj_and_type_to_str(item) + "\n")
@@ -34,7 +41,7 @@ def _write_page_objects_rec(w_stream, obj_to_write, indent=0):
 		for key, value in obj_to_write.items():
 			line = tabs + str(key) + ":"
 
-			if isinstance(value, dict):
+			if _obj_is_a_dlst(value):
 				_write_page_objects_rec(w_stream, value, indent)
 			else:
 				line += " " + _obj_and_type_to_str(value)
@@ -43,7 +50,7 @@ def _write_page_objects_rec(w_stream, obj_to_write, indent=0):
 
 	elif isinstance(obj_to_write, set):
 		for item in obj_to_write:
-			if isinstance(item, (dict, list, set, tuple)):
+			if _obj_is_a_dlst(item):
 				_write_page_objects_rec(w_stream, item, indent)
 			else:
 				w_stream.write(tabs + _obj_and_type_to_str(item) + "\n")


### PR DESCRIPTION
Script write_page_objects.py explores recursively the objects in a PDF file's pages and records their hierachy in a .txt file.