### PR TITLE
Maximum recursion depth specified for scripts in pdf_obj_struct

### DIFF
--- a/pdf_obj_struct/pdf_obj_struct.py
+++ b/pdf_obj_struct/pdf_obj_struct.py
@@ -119,6 +119,9 @@ def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth, depth_limit,
 					_write_pdf_obj_struct_rec(item, w_stream, rec_depth,
 						depth_limit, obj_str_fnc, ind_obj_fnc)
 
+				else:
+					w_stream.write(tabs + _TAB + "[...]\n")
+
 			else:
 				line += obj_str_fnc(item)
 				w_stream.write(line + "\n")
@@ -136,6 +139,9 @@ def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth, depth_limit,
 					_write_pdf_obj_struct_rec(value, w_stream, rec_depth,
 						depth_limit, obj_str_fnc, ind_obj_fnc)
 
+				else:
+					w_stream.write(tabs + _TAB + "[...]\n")
+
 			else:
 				line += obj_str_fnc(value)
 				w_stream.write(line + "\n")
@@ -152,6 +158,9 @@ def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth, depth_limit,
 				if depth_limit<=0 or rec_depth<=depth_limit:
 					_write_pdf_obj_struct_rec(item, w_stream, rec_depth,
 						depth_limit, obj_str_fnc, ind_obj_fnc)
+
+				else:
+					w_stream.write(tabs + _TAB + "[...]\n")
 
 			else:
 				line += obj_str_fnc(item)

--- a/pdf_obj_struct/pdf_obj_struct.py
+++ b/pdf_obj_struct/pdf_obj_struct.py
@@ -5,7 +5,7 @@ embedded in one another and other objects.
 """
 
 
-from PyPDF2.generic import IndirectObject
+from PyPDF2.generic import BooleanObject, IndirectObject
 
 
 _DLST = (dict, list, set, tuple)
@@ -25,7 +25,11 @@ def _make_tabs(n):
 
 
 def _obj_and_type_to_str(obj):
-	return str(obj) + " " + str(type(obj))
+	if isinstance(obj, BooleanObject):
+		return str(obj.value) + " " + str(type(obj))
+
+	else:
+		return str(obj) + " " + str(type(obj))
 
 
 def obj_is_a_dlst(obj):

--- a/pdf_obj_struct/pdf_obj_struct.py
+++ b/pdf_obj_struct/pdf_obj_struct.py
@@ -43,7 +43,7 @@ def obj_is_a_dlst(obj):
 	return isinstance(obj, _DLST)
 
 
-def _res_pdf_ind_object(obj):
+def _rslv_pdf_ind_object(obj):
 	if isinstance(obj, IndirectObject):
 		return obj.getObject()
 
@@ -56,7 +56,7 @@ def _return_arg(obj):
 
 
 def write_pdf_obj_struct(struct, w_stream, write_types=False,
-		res_ind_objs=False, depth_limit=0):
+		rslv_ind_objs=False, depth_limit=0):
 	"""
 	Writes a PDF object structure in a file stream. The indentation indicates
 	which objects are contained in others. The stream's mode must be "a",
@@ -70,7 +70,7 @@ def write_pdf_obj_struct(struct, w_stream, write_types=False,
 			structure's representation
 		write_types (bool): If True, this method will write the contained
 			objects' type in the stream. Defaults to False.
-		res_ind_objs (bool): If True, the indirect objects found in the
+		rslv_ind_objs (bool): If True, the indirect objects found in the
 			structure will be resolved. Defaults to False. WARNING! Setting
 			this parameter to True can make the function exceed the maximum
 			recursion depth.
@@ -86,7 +86,7 @@ def write_pdf_obj_struct(struct, w_stream, write_types=False,
 			+ "\"a\", \"a+\", \"r+\", \"w\" or \"w+\".")
 
 	obj_str_fnc = _obj_and_type_to_str if write_types else str
-	ind_obj_fnc = _res_pdf_ind_object if res_ind_objs else _return_arg
+	ind_obj_fnc = _rslv_pdf_ind_object if rslv_ind_objs else _return_arg
 
 	if obj_is_a_dlst(struct):
 		w_stream.write(str(type(struct)) + "\n")
@@ -95,12 +95,12 @@ def write_pdf_obj_struct(struct, w_stream, write_types=False,
 	else:
 		rec_depth = 0
 
-	_write_pdf_obj_struct_rec(struct, w_stream, rec_depth, depth_limit,
-		obj_str_fnc, ind_obj_fnc)
+	_write_pdf_obj_struct_rec(struct, w_stream, rec_depth,
+		depth_limit, obj_str_fnc, ind_obj_fnc)
 
 
-def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth, depth_limit,
-		obj_str_fnc, ind_obj_fnc):
+def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth,
+		depth_limit, obj_str_fnc, ind_obj_fnc):
 	tabs = _make_tabs(rec_depth)
 	rec_depth += 1
 

--- a/pdf_obj_struct/pdf_obj_struct.py
+++ b/pdf_obj_struct/pdf_obj_struct.py
@@ -55,8 +55,8 @@ def _return_arg(obj):
 	return obj
 
 
-def write_pdf_obj_struct(struct, w_stream,
-		write_types=False, res_ind_objs=False):
+def write_pdf_obj_struct(struct, w_stream, write_types=False,
+		res_ind_objs=False, depth_limit=0):
 	"""
 	Writes a PDF object structure in a file stream. The indentation indicates
 	which objects are contained in others. The stream's mode must be "a",
@@ -74,6 +74,8 @@ def write_pdf_obj_struct(struct, w_stream,
 			structure will be resolved. Defaults to False. WARNING! Setting
 			this parameter to True can make the function exceed the maximum
 			recursion depth.
+		depth_limit (int): a limit to the recursion depth. If it is set to 0
+			or less, no limit is enforced. Defaults to 0.
 
 	Raises:
 		RecursionError: if this function exceeds the maximum recursion depth
@@ -88,19 +90,19 @@ def write_pdf_obj_struct(struct, w_stream,
 
 	if obj_is_a_dlst(struct):
 		w_stream.write(str(type(struct)) + "\n")
-		indent = 1
+		rec_depth = 1
 
 	else:
-		indent = 0
+		rec_depth = 0
 
-	_write_pdf_obj_struct_rec(struct, w_stream, indent,
+	_write_pdf_obj_struct_rec(struct, w_stream, rec_depth, depth_limit,
 		obj_str_fnc, ind_obj_fnc)
 
 
-def _write_pdf_obj_struct_rec(obj_to_write, w_stream, indent,
+def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth, depth_limit,
 		obj_str_fnc, ind_obj_fnc):
-	tabs = _make_tabs(indent)
-	indent += 1
+	tabs = _make_tabs(rec_depth)
+	rec_depth += 1
 
 	if isinstance(obj_to_write, _LT):
 		length = len(obj_to_write)
@@ -112,8 +114,10 @@ def _write_pdf_obj_struct_rec(obj_to_write, w_stream, indent,
 			if obj_is_a_dlst(item):
 				line += str(type(item))
 				w_stream.write(line + "\n")
-				_write_pdf_obj_struct_rec(item, w_stream, indent,
-					obj_str_fnc, ind_obj_fnc)
+
+				if depth_limit<=0 or rec_depth<=depth_limit:
+					_write_pdf_obj_struct_rec(item, w_stream, rec_depth,
+						depth_limit, obj_str_fnc, ind_obj_fnc)
 
 			else:
 				line += obj_str_fnc(item)
@@ -127,8 +131,10 @@ def _write_pdf_obj_struct_rec(obj_to_write, w_stream, indent,
 			if obj_is_a_dlst(value):
 				line += str(type(value))
 				w_stream.write(line + "\n")
-				_write_pdf_obj_struct_rec(value, w_stream, indent,
-					obj_str_fnc, ind_obj_fnc)
+
+				if depth_limit<=0 or rec_depth<=depth_limit:
+					_write_pdf_obj_struct_rec(value, w_stream, rec_depth,
+						depth_limit, obj_str_fnc, ind_obj_fnc)
 
 			else:
 				line += obj_str_fnc(value)
@@ -142,8 +148,10 @@ def _write_pdf_obj_struct_rec(obj_to_write, w_stream, indent,
 			if obj_is_a_dlst(item):
 				line += str(type(item))
 				w_stream.write(line + "\n")
-				_write_pdf_obj_struct_rec(item, w_stream, indent,
-					obj_str_fnc, ind_obj_fnc)
+
+				if depth_limit<=0 or rec_depth<=depth_limit:
+					_write_pdf_obj_struct_rec(item, w_stream, rec_depth,
+						depth_limit, obj_str_fnc, ind_obj_fnc)
 
 			else:
 				line += obj_str_fnc(item)

--- a/pdf_obj_struct/pdf_obj_struct.py
+++ b/pdf_obj_struct/pdf_obj_struct.py
@@ -9,15 +9,21 @@ from PyPDF2.generic import BooleanObject, IndirectObject
 
 
 _DLST = (dict, list, set, tuple)
-
-
 _LT = (list, tuple)
-
 
 _STREAM_WRITING_MODES = ("a", "a+", "r+", "w", "w+")
 
-
+_CLOSING_BRACET_COLON_SPACE = "]: "
+_COLON_SPACE = ": "
+_NEW_LINE = "\n"
+_OPENING_BRACKET = "["
+_SPACE = " "
 _TAB = "\t"
+_UNEXPLORED_OBJS = "\t[...]\n"
+
+
+def _index_between_brackets(index):
+	return _OPENING_BRACKET + str(index) + _CLOSING_BRACET_COLON_SPACE
 
 
 def _make_tabs(n):
@@ -26,10 +32,10 @@ def _make_tabs(n):
 
 def _obj_and_type_to_str(obj):
 	if isinstance(obj, BooleanObject):
-		return str(obj.value) + " " + str(type(obj))
+		return str(obj.value) + _SPACE + str(type(obj))
 
 	else:
-		return str(obj) + " " + str(type(obj))
+		return str(obj) + _SPACE + str(type(obj))
 
 
 def obj_is_a_dlst(obj):
@@ -93,7 +99,7 @@ def write_pdf_obj_struct(struct, w_stream, write_types=False,
 	ind_obj_fnc = _rslv_pdf_ind_object if rslv_ind_objs else _return_arg
 
 	if obj_is_a_dlst(struct):
-		w_stream.write(str(type(struct)) + "\n")
+		w_stream.write(str(type(struct)) + _NEW_LINE)
 		rec_depth = 1
 
 	else:
@@ -113,42 +119,42 @@ def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth,
 
 		for i in range(length):
 			item = ind_obj_fnc(obj_to_write[i])
-			line = tabs + "[" + str(i) + "]: "
+			line = tabs + _index_between_brackets(i)
 
 			if obj_is_a_dlst(item):
 				line += str(type(item))
-				w_stream.write(line + "\n")
+				w_stream.write(line + _NEW_LINE)
 
 				if depth_limit<=0 or rec_depth<=depth_limit:
 					_write_pdf_obj_struct_rec(item, w_stream, rec_depth,
 						depth_limit, obj_str_fnc, ind_obj_fnc)
 
 				else:
-					w_stream.write(tabs + _TAB + "[...]\n")
+					w_stream.write(tabs + _UNEXPLORED_OBJS)
 
 			else:
 				line += obj_str_fnc(item)
-				w_stream.write(line + "\n")
+				w_stream.write(line + _NEW_LINE)
 
 	elif isinstance(obj_to_write, dict):
 		for key, value in obj_to_write.items():
 			value = ind_obj_fnc(value)
-			line = tabs + str(key) + ": "
+			line = tabs + str(key) + _COLON_SPACE
 
 			if obj_is_a_dlst(value):
 				line += str(type(value))
-				w_stream.write(line + "\n")
+				w_stream.write(line + _NEW_LINE)
 
 				if depth_limit<=0 or rec_depth<=depth_limit:
 					_write_pdf_obj_struct_rec(value, w_stream, rec_depth,
 						depth_limit, obj_str_fnc, ind_obj_fnc)
 
 				else:
-					w_stream.write(tabs + _TAB + "[...]\n")
+					w_stream.write(tabs + _UNEXPLORED_OBJS)
 
 			else:
 				line += obj_str_fnc(value)
-				w_stream.write(line + "\n")
+				w_stream.write(line + _NEW_LINE)
 
 	elif isinstance(obj_to_write, set):
 		for item in obj_to_write:
@@ -157,19 +163,19 @@ def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth,
 
 			if obj_is_a_dlst(item):
 				line += str(type(item))
-				w_stream.write(line + "\n")
+				w_stream.write(line + _NEW_LINE)
 
 				if depth_limit<=0 or rec_depth<=depth_limit:
 					_write_pdf_obj_struct_rec(item, w_stream, rec_depth,
 						depth_limit, obj_str_fnc, ind_obj_fnc)
 
 				else:
-					w_stream.write(tabs + _TAB + "[...]\n")
+					w_stream.write(tabs + _UNEXPLORED_OBJS)
 
 			else:
 				line += obj_str_fnc(item)
-				w_stream.write(line + "\n")
+				w_stream.write(line + _NEW_LINE)
 
 	else:
 		line = tabs + obj_str_fnc(obj_to_write)
-		w_stream.write(line + "\n")
+		w_stream.write(line + _NEW_LINE)

--- a/pdf_obj_struct/write_field_objects.py
+++ b/pdf_obj_struct/write_field_objects.py
@@ -68,6 +68,10 @@ if __name__ == "__main__":
 	except IndexError:
 		depth_limit = 0
 
+	except ValueError as ve:
+		print("Argument 2: " + str(ve))
+		exit()
+
 	# Output path checks
 	try:
 		output_path = argv[3]

--- a/pdf_obj_struct/write_field_objects.py
+++ b/pdf_obj_struct/write_field_objects.py
@@ -5,7 +5,8 @@ structure in a .txt file.
 Args:
 	1: (str) the path to the PDF file to explore
 	2: (int, optional) the limit to the recursion depth that the algorithm
-		can reach. Defaults to 0.
+		can reach. If 0 or less, no limit is set, and PyPDF2's indirect
+		objects will not be resolved. Defaults to 0.
 	3: (str, optional) the path to the .txt output file
 """
 

--- a/pdf_obj_struct/write_field_objects.py
+++ b/pdf_obj_struct/write_field_objects.py
@@ -65,7 +65,8 @@ if __name__ == "__main__":
 	reader = PdfFileReader(input_path.open(mode="rb"))
 
 	with output_path.open(mode="w") as output_stream:
-		output_stream.write("Fields of " + str(input_path) + "\n")
+		output_stream.write("Objects in the fields of "
+			+ str(input_path) + "\n")
 
 		for mapping_name, field in reader.getFields().items():
 			output_stream.write("\n" + mapping_name + "\n")

--- a/pdf_obj_struct/write_field_objects.py
+++ b/pdf_obj_struct/write_field_objects.py
@@ -3,8 +3,10 @@ Explores recursively the objects in a PDF file's fields and records their
 structure in a .txt file.
 
 Args:
-	1: the path to the PDF file to explore
-	2: (optional) the path to the .txt output file
+	1: (str) the path to the PDF file to explore
+	2: (int, optional) the limit to the recursion depth that the algorithm
+		can reach. Defaults to 0.
+	3: (str, optional) the path to the .txt output file
 """
 
 
@@ -47,9 +49,16 @@ if __name__ == "__main__":
 			+ _INPUT_EXTENSION + " file.")
 		exit()
 
+	# Recursion depth limit check
+	try:
+		depth_limit = int(argv[2])
+
+	except IndexError:
+		depth_limit = 0
+
 	# Output path checks
 	try:
-		output_path = Path(argv[2])
+		output_path = Path(argv[3])
 
 		if output_path.is_dir():
 			output_path = output_path/_make_default_output_file_name(input_path)
@@ -70,4 +79,5 @@ if __name__ == "__main__":
 
 		for mapping_name, field in reader.getFields().items():
 			output_stream.write("\n" + mapping_name + "\n")
-			write_pdf_obj_struct(field, output_stream, True)
+			write_pdf_obj_struct(field, output_stream,
+				True, depth_limit>0, depth_limit)

--- a/pdf_obj_struct/write_page_objects.py
+++ b/pdf_obj_struct/write_page_objects.py
@@ -68,6 +68,10 @@ if __name__ == "__main__":
 	except IndexError:
 		depth_limit = 0
 
+	except ValueError as ve:
+		print("Argument 2: " + str(ve))
+		exit()
+
 	# Output path checks
 	try:
 		output_path = argv[3]

--- a/pdf_obj_struct/write_page_objects.py
+++ b/pdf_obj_struct/write_page_objects.py
@@ -5,7 +5,8 @@ structure in a .txt file.
 Args:
 	1: (str) the path to the PDF file to explore
 	2: (int, optional) the limit to the recursion depth that the algorithm
-		can reach. Defaults to 0.
+		can reach. If 0 or less, no limit is set, and PyPDF2's indirect
+		objects will not be resolved. Defaults to 0.
 	3: (str, optional) the path to the .txt output file
 """
 

--- a/pdf_obj_struct/write_page_objects.py
+++ b/pdf_obj_struct/write_page_objects.py
@@ -1,13 +1,14 @@
 """
-Explores recursively the objects in a PDF file's pages and records their
-structure in a .txt file.
+Explores recursively the object structure in a PDF file's pages and records
+their structure in a .txt file.
 
 Args:
 	1: (str) the path to the PDF file to explore
 	2: (int, optional) the limit to the recursion depth that the algorithm
 		can reach. If 0 or less, no limit is set, and PyPDF2's indirect
 		objects will not be resolved. Defaults to 0.
-	3: (str, optional) the path to the .txt output file
+	3: (str, optional) the path to the .txt output file. If set to "console",
+		the object structure will be written in the console.
 """
 
 
@@ -31,6 +32,15 @@ def _make_default_output_file_stem(input_path):
 	return input_path.stem + "_page_objects"
 
 
+def _write_page_objs_in_console(pdf_path, pages, w_stream, depth_limit):
+	w_stream.write("Objects in the pages of " + str(pdf_path) + "\n")
+
+	for i in range(len(pages)):
+		page = pages[i]
+		w_stream.write("\n\nPAGE " + str(i) + "\n")
+		write_pdf_obj_struct(page, w_stream, True, depth_limit>0, depth_limit)
+
+
 if __name__ == "__main__":
 
 	# Input path checks
@@ -45,7 +55,8 @@ if __name__ == "__main__":
 		print("ERROR! " + str(input_path) + " does not exist.")
 		exit()
 
-	elif input_path.suffixes != _INPUT_EXTENSION_IN_LIST: # False if not a file
+	elif input_path.suffixes != _INPUT_EXTENSION_IN_LIST:
+		# False if not a file
 		print("ERROR! The first argument must be the path to a "
 			+ _INPUT_EXTENSION + " file.")
 		exit()
@@ -59,28 +70,34 @@ if __name__ == "__main__":
 
 	# Output path checks
 	try:
-		output_path = Path(argv[3])
+		output_path = argv[3]
 
-		if output_path.is_dir():
-			output_path = output_path/_make_default_output_file_name(input_path)
+		if output_path.lower() == "console":
+			output_path = None
 
-		elif output_path.suffixes != _OUTPUT_EXTENSION_IN_LIST:
-			output_path = output_path.with_suffix(_OUTPUT_EXTENSION)
+		else:
+			output_path = Path(output_path)
+
+			if output_path.is_dir():
+				output_path =\
+					output_path/_make_default_output_file_name(input_path)
+
+			elif output_path.suffixes != _OUTPUT_EXTENSION_IN_LIST:
+				output_path = output_path.with_suffix(_OUTPUT_EXTENSION)
 
 	except IndexError:
 		output_path = input_path.with_name(
 			_make_default_output_file_name(input_path))
 
 	# Real work
-	reader = PdfFileReader(input_path.open("rb"))
+	reader = PdfFileReader(input_path.open(mode="rb"))
 	pages = reader.pages
 
-	with output_path.open("w") as output_stream:
-		output_stream.write("Objects in the pages of "
-			+ str(input_path) + "\n")
+	if output_path is None:
+		from sys import stdout
+		_write_page_objs_in_console(input_path, pages, stdout, depth_limit)
 
-		for i in range(len(pages)):
-			page = pages[i]
-			output_stream.write("\n\nPAGE " + str(i) + "\n")
-			write_pdf_obj_struct(page, output_stream,
-				True, depth_limit>0, depth_limit)
+	else:
+		with output_path.open(mode="w") as output_stream:
+			_write_page_objs_in_console(input_path, pages,
+				output_stream, depth_limit)

--- a/pdf_obj_struct/write_page_objects.py
+++ b/pdf_obj_struct/write_page_objects.py
@@ -66,7 +66,8 @@ if __name__ == "__main__":
 	pages = reader.pages
 
 	with output_path.open("w") as output_stream:
-		output_stream.write("Object hierachy of " + str(input_path) + "\n")
+		output_stream.write("Objects in the pages of "
+			+ str(input_path) + "\n")
 
 		for i in range(len(pages)):
 			page = pages[i]

--- a/pdf_obj_struct/write_page_objects.py
+++ b/pdf_obj_struct/write_page_objects.py
@@ -3,8 +3,10 @@ Explores recursively the objects in a PDF file's pages and records their
 structure in a .txt file.
 
 Args:
-	1: the path to the PDF file to explore
-	2: (optional) the path to the .txt output file
+	1: (str) the path to the PDF file to explore
+	2: (int, optional) the limit to the recursion depth that the algorithm
+		can reach. Defaults to 0.
+	3: (str, optional) the path to the .txt output file
 """
 
 
@@ -47,9 +49,16 @@ if __name__ == "__main__":
 			+ _INPUT_EXTENSION + " file.")
 		exit()
 
+	# Recursion depth limit check
+	try:
+		depth_limit = int(argv[2])
+
+	except IndexError:
+		depth_limit = 0
+
 	# Output path checks
 	try:
-		output_path = Path(argv[2])
+		output_path = Path(argv[3])
 
 		if output_path.is_dir():
 			output_path = output_path/_make_default_output_file_name(input_path)
@@ -72,4 +81,5 @@ if __name__ == "__main__":
 		for i in range(len(pages)):
 			page = pages[i]
 			output_stream.write("\n\nPAGE " + str(i) + "\n")
-			write_pdf_obj_struct(page, output_stream, True)
+			write_pdf_obj_struct(page, output_stream,
+				True, depth_limit>0, depth_limit)


### PR DESCRIPTION
* A script argument specifies the maximum recursion depth.
* The value of BooleanOjbects is written correctly.
* PDF object structures can be written in the console.