### PR TITLE
Jazal updated to version 2.0.0

### DIFF
--- a/field_setting/field_setting_parser.py
+++ b/field_setting/field_setting_parser.py
@@ -306,7 +306,7 @@ if __name__ == "__main__":
 	print_val_type = args.types
 
 	check_mandatory_path(
-		field_setting_path, "-f/--file", (".yml",), must_exist=True)
+		field_setting_path, "-f/--file", ".yml", must_exist=True)
 
 	yaml_content = get_yaml_content(field_setting_path)
 	field_values = parse_yaml_content(yaml_content)

--- a/fill_expense_report.py
+++ b/fill_expense_report.py
@@ -28,7 +28,7 @@ _ccAMOUNT_TOTAL_FIELD = "TotalccMontant$"
 
 _DFLT_TEMPLATE_PATH = Path("rapport_depenses.pdf")
 
-_PDF_EXTEN_TUPLE = (".pdf",)
+_PDF_EXTENSION = ".pdf"
 
 
 def _make_parser():
@@ -91,14 +91,14 @@ if __name__ == "__main__":
 	template_path = args.template # -t
 
 	check_mandatory_path(
-		output_path, "-o/--output", _PDF_EXTEN_TUPLE, must_exist=False)
+		output_path, "-o/--output", _PDF_EXTENSION, must_exist=False)
 
 	check_mandatory_path(
-		field_setting_path, "-s/--setting", (".yml",), must_exist=True)
+		field_setting_path, "-s/--setting", ".yml", must_exist=True)
 
 	if template_path != _DFLT_TEMPLATE_PATH:
 		check_mandatory_path(
-			template_path, "-t/--template", _PDF_EXTEN_TUPLE, must_exist=True)
+			template_path, "-t/--template", _PDF_EXTENSION, must_exist=True)
 
 	template = PdfFileReader(template_path.open(mode="rb"), strict=False)
 	writer = make_writer_from_reader(template, args.editable)

--- a/fill_expense_report.py
+++ b/fill_expense_report.py
@@ -8,8 +8,7 @@ from argparse import ArgumentParser
 from field_setting import\
 	get_yaml_content,\
 	parse_yaml_content
-from path_arg_checks import\
-	check_mandatory_path
+from path_arg_checks import check_mandatory_path
 from pathlib import Path
 from PyPDF2 import PdfFileReader
 from pypdf2_util import\

--- a/fill_expense_report.py
+++ b/fill_expense_report.py
@@ -9,8 +9,7 @@ from field_setting import\
 	get_yaml_content,\
 	parse_yaml_content
 from path_arg_checks import\
-	check_mandatory_path,\
-	check_optional_path
+	check_mandatory_path
 from pathlib import Path
 from PyPDF2 import PdfFileReader
 from pypdf2_util import\

--- a/fill_expense_report.py
+++ b/fill_expense_report.py
@@ -28,6 +28,7 @@ _ccAMOUNT_TOTAL_FIELD = "TotalccMontant$"
 _DFLT_TEMPLATE_PATH = Path("rapport_depenses.pdf")
 
 _PDF_EXTENSION = ".pdf"
+_YML_EXTENSION = ".yml"
 
 
 def _make_parser():
@@ -93,7 +94,7 @@ if __name__ == "__main__":
 		output_path, "-o/--output", _PDF_EXTENSION, must_exist=False)
 
 	check_mandatory_path(
-		field_setting_path, "-s/--setting", ".yml", must_exist=True)
+		field_setting_path, "-s/--setting", _YML_EXTENSION, must_exist=True)
 
 	if template_path != _DFLT_TEMPLATE_PATH:
 		check_mandatory_path(

--- a/path_arg_checks.py
+++ b/path_arg_checks.py
@@ -81,8 +81,7 @@ def check_mandatory_path(path_obj, path_arg_name, path_exten, must_exist):
 		must_exist (bool): If it is set to True, the existence of the file to
 			which the path argument points is verified.
 	"""
-	missing_path_warner = MissingPathArgWarner(
-		path_arg_name, path_exten)
+	missing_path_warner = MissingPathArgWarner(path_arg_name, path_exten)
 
 	if path_obj is None:
 		print(_ERROR_INTRO + missing_path_warner.make_missing_arg_msg())

--- a/path_arg_checks.py
+++ b/path_arg_checks.py
@@ -35,12 +35,12 @@ def check_io_path_pair(input_path, input_path_name, input_path_exten,
 	Args:
 		input_path (pathlib.Path): the input path
 		input_path_name (str): the input path argument's name
-		input_path_exten (str tuple): the extension that the input path is
-			supposed to have
+		input_path_exten (str): the extension that the input path is supposed
+			to have
 		output_path (pathlib.Path): the output path
 		output_path_name (str): the output path argument's name
-		output_path_exten (str tuple): the extension that the output path is
-			supposed to have
+		output_path_exten (str): the extension that the output path is supposed
+			to have
 		dflt_output_termin (str): a string appended to input_path's file name
 			to make a default output file name if necessary
 
@@ -76,8 +76,8 @@ def check_mandatory_path(path_obj, path_arg_name, path_exten, must_exist):
 		path_obj (pathlib.Path): the path argument being checked. Set this
 			parameter to None to indicate that the path was not provided.
 		path_arg_name (str): the name of the path argument
-		path_exten (str tuple): the extension that path_obj is supposed to
-			have. It must conform to the specification of the Jazal library.
+		path_exten (str): the extension that path_obj is supposed to have. It
+			must conform to the specification of the Jazal library.
 		must_exist (bool): If it is set to True, the existence of the file to
 			which the path argument points is verified.
 	"""
@@ -118,8 +118,8 @@ def check_optional_path(
 		path_obj (pathlib.Path): the path argument being checked. Set this
 			parameter to None to indicate that the path was not provided.
 		path_arg_name (str): the name of the path argument
-		path_exten (str tuple): the extension that path_obj is supposed to
-			have. It must conform to the specification of the Jazal library.
+		path_exten (str): the extension that path_obj is supposed to have. It
+			must conform to the specification of the Jazal library.
 		base_path (pathlib.Path): this path can serve as a base to generate a
 			default value for the checked path.
 		termination (str): a string appended to base_path's file name to make a

--- a/pdf_field_values.py
+++ b/pdf_field_values.py
@@ -80,8 +80,8 @@ if __name__ == "__main__":
 		output_path = None
 
 	output_path = check_io_path_pair(
-		input_path, "Input file", (".pdf",),
-		output_path, "Output file", (".txt",),
+		input_path, "Input file", ".pdf",
+		output_path, "Output file", ".txt",
 		"_field_values")
 
 	reader = PdfFileReader(input_path.open(mode="rb"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2020.12.5
-jazal==1.0.0
+jazal==2.0.0
 pathlib==1.0.1
 PyPDF2==1.26.0
 PyYAML==5.4.1

--- a/write_field_names.py
+++ b/write_field_names.py
@@ -17,6 +17,8 @@ from pypdf2_util import\
 from sys import argv
 
 
+_PDF_EXTENSION = ".pdf"
+
 TEXT_FIELD_TYPE = "/Tx"
 
 
@@ -42,10 +44,9 @@ try:
 except IndexError:
 	output_path = None
 
-pdf_extension = (".pdf",)
 output_path = check_io_path_pair(
-	input_path, "Input file", pdf_extension,
-	output_path, "Output file", pdf_extension,
+	input_path, "Input file", _PDF_EXTENSION,
+	output_path, "Output file", _PDF_EXTENSION,
 	"_field_names")
 
 reader = PdfFileReader(input_path.open(mode="rb"))


### PR DESCRIPTION
The path extensions are given as strings rather than tuples or lists of suffixes.